### PR TITLE
prompt: fix usage on OpenBSD Korn Shell (#1)

### DIFF
--- a/kiss
+++ b/kiss
@@ -625,7 +625,7 @@ pkg_build() {
     log "Building: $*"
 
     # Only ask for confirmation if more than one package needs to be built.
-    [ "$#" -gt 1 ] || [ "$pkg_update" ] && prompt
+    [ "$#" -gt 1 ] || [ "$pkg_update" ] && { prompt || exit 0 ;}
 
     for pkg do pkg_lint "$pkg"; done
 
@@ -1400,7 +1400,7 @@ pkg_updates() {
         log "Detected package manager update"
         log "The package manager will be updated first"
 
-        prompt
+        prompt || exit 0
 
         pkg_build kiss
         args i kiss


### PR DESCRIPTION
OpenBSD Korn Shell doesn't exit when the prompt receives interrupt. This
fixes the issue by manually exiting when prompt returns error. This
issue is an OpenBSD Korn Shell bug and doesn't match the expected POSIX
behaviour.